### PR TITLE
📄 rpn内でthrowされるErrorの再検討

### DIFF
--- a/src/utils/rpn.ts
+++ b/src/utils/rpn.ts
@@ -347,8 +347,7 @@ export function rpnCalculation(rpnExp: string): string | number | undefined {
         }
     }
 
-    // 失敗の判定
-    // ・演算子の不足(項が余ってしまう)時に投げられる
+    // 演算子の不足(項が余ってしまう)時に投げられる
     if (calcStack.length !== 1) {
         throw new CalculateUnfinishedError('too enough term');
     }


### PR DESCRIPTION
rpn.tsの352行目でthrowされるErrorは、すぐ上のwhile文の終了時に`calcStack`に未演算の項が残っている時なので、`項が多すぎます`とさせました。

rpn.tsの494行目では、その少し上のwhile文の終了条件と等しいのでErrorはthrowされることがないと判断しました。それに伴い493~494行目が削除されています。

気持ち悪いので`// /`を`// `に、`（...）`を`(...)`に書き換えました。