### PR TITLE
コンテキストメニューの項目の表示順序を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 				{
 					"command": "mcdutil.commands.createFile",
 					"when": "explorerResourceIsFolder == true",
-					"group": "navigation@4"
+					"group": "MCDUtil@1"
 				},
 				{
 					"command": "mcdutil.commands.copyResourcePath",


### PR DESCRIPTION
エクスプローラー上のコンテキストメニューに追加される `データパックファイルを作成する` という項目が表示される位置を下げました