### PR TITLE
拡張機能がアクティベートされた時にコンテキストメニューの項目を表示する

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,12 +86,12 @@
 			"explorer/context": [
 				{
 					"command": "mcdutil.commands.createFile",
-					"when": "explorerResourceIsFolder == true",
+					"when": "explorerResourceIsFolder == true && showContextMenu == true",
 					"group": "navigation@4"
 				},
 				{
 					"command": "mcdutil.commands.copyResourcePath",
-					"when": "explorerResourceIsFolder == false",
+					"when": "explorerResourceIsFolder == false && showContextMenu == true",
 					"group": "6_copypath@31"
 				}
 			],

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"rfdc": "^1.1.4"
 	},
 	"activationEvents": [
+		"workspaceContains:**/pack.mcmeta",
 		"onCommand:mcdutil.commands.createDatapackTemplate",
 		"onCommand:mcdutil.commands.createFile",
 		"onCommand:mcdutil.commands.scoreOperation",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,9 @@ export function activate(context: ExtensionContext): void {
     disposable.push(workspace.onDidChangeConfiguration(updateConfig));
 
     context.subscriptions.push(...disposable);
+
+    // 拡張機能がアクティベートされた時にコンテキストメニューの項目を表示する
+    commands.executeCommand('setContext', 'showContextMenu', true);
 }
 
 function updateConfig(event: ConfigurationChangeEvent) {


### PR DESCRIPTION
開いたフォルダに `pack.mcmeta` が存在した場合に拡張機能をアクティベートするようにし、アクティベート時にコンテキストメニューの項目を表示するようにしました